### PR TITLE
ビルボードクラスのワールド行列計算を実装。それに伴ってカメラコンポーネントを改良

### DIFF
--- a/MakinoProject00/MakinoProject00/ApplicationMain.cpp
+++ b/MakinoProject00/MakinoProject00/ApplicationMain.cpp
@@ -132,7 +132,7 @@ public:
                 setting->ps = CShaderRegistry::GetAny().GetPS(PixelShaderType::StandardColor);
             }
             {
-                auto setting = standardSetting.AddOverrideSetting({ GraphicsComponentType::Sprite3D });
+                auto setting = standardSetting.AddOverrideSetting({ GraphicsComponentType::Sprite3D, GraphicsComponentType::Billboard });
                 setting->vs = CShaderRegistry::GetAny().GetVS(VertexShaderType::Standard3DSprite);
                 setting->rasterizerState = Gpso::RasterizerStateSetting();
                 setting->rasterizerState->cullMode = D3D12_CULL_MODE_NONE;
@@ -169,6 +169,10 @@ public:
         sprite2->AddComponent<CSprite3D>(GraphicsLayer::Standard, L"Texture/textest200x200.png");
         sprite2->AddComponent<RotateComponent>(Vector3f(0.0f, 1.0f, 0.0f).GetNormalize(), 3.0f);
 
+        // Billboard obj
+        auto billboard = CreateGameObject<CGameObject>(Transformf(Vector3f(0.0f, -1.5f, 0.0f), Vector3f::Ones(), Utl::DEG_2_RAD * Vector3f(0.0f, 0.0f, 0.0f)));
+        billboard->AddComponent<CBillboard>(GraphicsLayer::Standard, L"Texture/apollo11.png");
+
         // Box
         {
             auto box = CreateGameObject<CGameObject>(Transformf(Vector3f(0.0f, 0.0f, 0.0f), Vector3f::Ones(), Vector3f::Zero()));
@@ -200,6 +204,7 @@ public:
         // Camera obj
         auto camera = CreateGameObject<CGameObject>(Transformf(Vector3f(0.0f, 0.0f, -5.0f)));
         camera->AddComponent<CCameraComponent>(L"Main camera");
+        camera->AddComponent<RotateComponent>(Vector3f(0.0f, 1.0f, 0.0f), 0.1f);
     }
 
     void Draw() {

--- a/MakinoProject00/MakinoProject00/Camera.cpp
+++ b/MakinoProject00/MakinoProject00/Camera.cpp
@@ -3,11 +3,11 @@
 #include "Scene.h"
 
 // Constructor
-CCameraComponent::CCameraComponent(CGameObject* owner, std::wstring cameraName) 
+CCameraComponent::CCameraComponent(CGameObject* owner, std::wstring cameraName, bool isFocusMode)
     : ACComponent(owner)
     , m_name(std::move(cameraName))
     , m_priority(0)
-    , m_focus(Vector3f::Zero())
+    , m_isFocusMode(isFocusMode)
     , m_up(Utl::Math::UNIT3_Y)
     , m_fovAngleY(Utl::DEG_2_RAD * 60.0f)
     , m_aspect(16.0f / 9.0f)
@@ -18,36 +18,70 @@ CCameraComponent::CCameraComponent(CGameObject* owner, std::wstring cameraName)
 // Processing for the first update frame
 void CCameraComponent::Start() {
     m_gameObj->GetScene()->GetCameraRegistry()->AddCamera(this);
+
+    if (m_isFocusMode) {
+        m_focus = m_gameObj->GetTransform().pos + Utl::Math::UNIT3_Z;
+    }
+    else {
+        m_focus = m_gameObj->GetTransform().rotation * Utl::Math::UNIT3_Z;
+    }
+}
+
+// Apply the rotation of this gameobject to this look direction vector
+void CCameraComponent::ApplyRotation() {
+    // If not in focus mode, update look direction vector
+    if (false == m_isFocusMode) {
+        if (Utl::CheckEnumBit(m_gameObj->GetTransformObserve() & TransformObserve::Rotate)) {
+            m_focus = m_gameObj->GetTransform().rotation * Utl::Math::UNIT3_Z;
+
+            // Calculate rotation matrix
+            m_rotationMatrix = GenerateViewMatrix();
+            m_rotationMatrix = DirectX::XMMatrixInverse(nullptr, m_rotationMatrix);
+            m_rotationMatrix.r[3] = DirectX::XMVectorSet(0.0f, 0.0f, 0.0f, 1.0f);
+        }
+    }
+    else {
+        // Calculate rotation matrix
+        m_rotationMatrix = GenerateViewMatrix();
+        m_rotationMatrix = DirectX::XMMatrixInverse(nullptr, m_rotationMatrix);
+        m_rotationMatrix.r[3] = DirectX::XMVectorSet(0.0f, 0.0f, 0.0f, 1.0f);
+    }
 }
 
 // Generate a view matrix
-DirectX::XMFLOAT4X4 CCameraComponent::GenerateViewMatrix() {
+DirectX::XMMATRIX CCameraComponent::GenerateViewMatrix() {
     DirectX::XMMATRIX mat;
 
     // Get the position of this game object
-    Vector3f pos = m_gameObj->GetTransform().pos;
+    const Vector3f& pos = m_gameObj->GetTransform().pos;
 
-    // If this position and the fucus position as the same, shift the coordinate a little
-    if (Utl::Math::IsEqualVector3f(pos, m_focus)) {
-        pos.y() += 0.1f;
+    Vector3f focus;
+    // If in focus mode, use focus position
+    if (m_isFocusMode) {
+        // If this position and the fucus position as the same, shift the coordinate a little
+        if (Utl::Math::IsEqualVector3f(pos, m_focus)) {
+            focus = m_focus + Vector3f(0.0f, 0.0f, 0.01f);
+        }
+        else {
+            focus = m_focus;
+        }
+    }
+    // If not in focus mode, use look direction vector
+    else {
+        focus = pos + m_focus;
     }
 
     // Create a view matrix
     mat = DirectX::XMMatrixLookAtLH(
         DirectX::XMVectorSet(pos.x(), pos.y(), pos.z(), 0.0f),
-        DirectX::XMVectorSet(m_focus.x(), m_focus.y(), m_focus.z(), 0.0f),
+        DirectX::XMVectorSet(focus.x(), focus.y(), focus.z(), 0.0f),
         DirectX::XMVectorSet(m_up.x(), m_up.y(), m_up.z(), 0.0f)
     );
-    
-    // Convert XMMATRIX to XMFLOAT4X4
-    DirectX::XMFLOAT4X4 ret;
-    DirectX::XMStoreFloat4x4(&ret, mat);
-
-    return ret;
+    return mat;
 }
 
 // Generate a projection matrix
-DirectX::XMFLOAT4X4 CCameraComponent::GenerateProjectionMatrix() {
+DirectX::XMMATRIX CCameraComponent::GenerateProjectionMatrix() {
     DirectX::XMMATRIX mat;
 
     // Create a projection matrix
@@ -57,33 +91,15 @@ DirectX::XMFLOAT4X4 CCameraComponent::GenerateProjectionMatrix() {
         m_near,      // Distance to start projecting on screen
         m_far        // Distance to end projecting on screen
     );
-
-    // Convert XMMATRIX to XMFLOAT4X4
-    DirectX::XMFLOAT4X4 ret;
-    DirectX::XMStoreFloat4x4(&ret, mat);
-
-    return ret;
+    return mat;
 }
 
 // Generate a view projection matrix
 DirectX::XMFLOAT4X4 CCameraComponent::GenerateViewProjectionMatrix() {
     DirectX::XMMATRIX mat;
 
-    // Get the position of this game object
-    Vector3f pos = m_gameObj->GetTransform().pos;
-
-    // If this position and the fucus position as the same, shift the coordinate a little
-    if (Utl::Math::IsEqualVector3f(pos, m_focus)) {
-        pos.y() += 0.1f;
-    }
-
     // Create a view projection matrix
-    mat = 
-        DirectX::XMMatrixLookAtLH(
-            DirectX::XMVectorSet(pos.x(), pos.y(), pos.z(), 0.0f),
-            DirectX::XMVectorSet(m_focus.x(), m_focus.y(), m_focus.z(), 0.0f),
-            DirectX::XMVectorSet(m_up.x(), m_up.y(), m_up.z(), 0.0f)) * 
-        DirectX::XMMatrixPerspectiveFovLH(m_fovAngleY, m_aspect, m_near, m_far);
+    mat = GenerateViewMatrix() * GenerateProjectionMatrix();
 
     // Convert XMMATRIX to XMFLOAT4X4
     DirectX::XMFLOAT4X4 ret;

--- a/MakinoProject00/MakinoProject00/Camera.h
+++ b/MakinoProject00/MakinoProject00/Camera.h
@@ -18,8 +18,9 @@ public:
        @brief Constructor
        @param owner Game object that is the owner of this component
        @param cameraName Name of this camera
+       @param isFocusMode True if focus position is handled, false if viewpoint direction vector is handled
     */
-    CCameraComponent(CGameObject* owner, std::wstring cameraName);
+    CCameraComponent(CGameObject* owner, std::wstring cameraName, bool isFocusMode = false);
 
     /**
        @brief Processing for the first update frame
@@ -32,16 +33,21 @@ public:
     void Update() override {}
 
     /**
+       @brief Apply the rotation of this gameobject to this look direction vector
+    */
+    void ApplyRotation();
+
+    /**
        @brief Generate a view matrix
        @return View matrix
     */
-    DirectX::XMFLOAT4X4 GenerateViewMatrix();
+    DirectX::XMMATRIX GenerateViewMatrix();
 
     /**
        @brief Generate a projection matrix
        @return Projection matrix
     */
-    DirectX::XMFLOAT4X4 GenerateProjectionMatrix();
+    DirectX::XMMATRIX GenerateProjectionMatrix();
 
     /**
        @brief Generate a view projection matrix
@@ -57,10 +63,10 @@ public:
     /** @brief Set a priority to this camera */
     void SetPriority(int priority) { m_priority = priority; }
 
-    /** @brief Get the focus position */
+    /** @brief Get the focus position if in focus mode, otherwise, look direction vector */
     const Vector3f& GetFocus() const { return m_focus; }
-    /** @brief Set a focus position */
-    void SetFocus(const Vector3f& focus) { m_focus = focus; }
+    /** @brief Set a focus position. Value will not change unless in focus mode */
+    void SetFocus(const Vector3f& focus) { if (m_isFocusMode) { m_focus = focus; } }
 
     /** @brief Get the up vector */
     const Vector3f& GetUp() const { return m_up; }
@@ -87,13 +93,18 @@ public:
     /** @brief Set a far clipping value */
     void SetFar(float farValue) { m_far = farValue; }
 
+    /** @brief Get matrix with the same rotation as the view matrix of this camera */
+    const DirectX::XMMATRIX& GetRotationMatrix() { return m_rotationMatrix; }
+
 private:
     /** @brief Name of this camera */
     const std::wstring m_name;
     /** @brief Camera priority */
     int m_priority;
+    /** @brief Is the camera's focus position handled in focus mode? */
+    bool m_isFocusMode;
 
-    /** @brief Focus position */
+    /** @brief Focus position if in focus mode, otherwise, look direction vector */
     Vector3f m_focus;
     /** @brief Up vector */
     Vector3f m_up;
@@ -105,6 +116,9 @@ private:
     float m_near;
     /** @brief Far clipping value */
     float m_far;
+
+    /** @brief Matrix with the same rotation as the view matrix of this camera */
+    DirectX::XMMATRIX m_rotationMatrix;
 };
 
 #endif // !__CAMERA_H__

--- a/MakinoProject00/MakinoProject00/CameraRegistry.cpp
+++ b/MakinoProject00/MakinoProject00/CameraRegistry.cpp
@@ -1,6 +1,14 @@
 ﻿#include "CameraRegistry.h"
 #include "Application.h"
 
+// Processing at the end of the update process
+void CCameraRegistry::EndUpdate() {
+    // Apply the rotation to look direction vector
+    for (auto& it : m_cameras) {
+        it->ApplyRotation();
+    }
+}
+
 // Get a camera with highest priority
 CWeakPtr<CCameraComponent> CCameraRegistry::GetCameraPriority() const {
     int highestPriority = Utl::Limit::INT_LOWEST;

--- a/MakinoProject00/MakinoProject00/CameraRegistry.h
+++ b/MakinoProject00/MakinoProject00/CameraRegistry.h
@@ -24,6 +24,11 @@ public:
     ~CCameraRegistry() = default;
 
     /**
+       @brief Processing at the end of the update process
+    */
+    void EndUpdate();
+
+    /**
        @brief Get a camera with highest priority
        @return Weak pointer to camera component
     */

--- a/MakinoProject00/MakinoProject00/DynamicCbWorldMat.h
+++ b/MakinoProject00/MakinoProject00/DynamicCbWorldMat.h
@@ -30,6 +30,8 @@ protected:
     Utl::Dx::CPU_DESCRIPTOR_HANDLE AllocateData(CSpriteUI* sprite);
     /** @brief Allocate data for sprite 3D */
     Utl::Dx::CPU_DESCRIPTOR_HANDLE AllocateData(CSprite3D* sprite);
+    /** @brief Allocate data for billboard */
+    Utl::Dx::CPU_DESCRIPTOR_HANDLE AllocateData(CBillboard* billboard);
 };
 
 #endif // !__DYNAMIC_CB_WORLD_MAT_H__

--- a/MakinoProject00/MakinoProject00/Scene.cpp
+++ b/MakinoProject00/MakinoProject00/Scene.cpp
@@ -68,6 +68,9 @@ void ACScene::Update() {
         // Pre drawing processing
         it->PreDraw();
     }
+
+    // Perform processing at the end of the update process from camera registry
+    m_cameraRegistry->EndUpdate();
 }
 
 // Processing at end of a frame


### PR DESCRIPTION
# 概要
* ワールド行列定数バッファクラスにビルボードクラス用の計算を実装
* カメラが注視点を使用するか、視点方向ベクトルを使用するかを選択し、視点方向ベクトルを使用する場合は自動で回転を適用するように
* カメラレジストリに更新終了処理を実装