### PR TITLE
ApplicationMainに直書きしていたテスト用のコンポーネントやシーンをSampleとして別ファイルに分けてリファクタリング

### DIFF
--- a/MakinoProject00/MakinoProject00/ApplicationMain.cpp
+++ b/MakinoProject00/MakinoProject00/ApplicationMain.cpp
@@ -16,256 +16,16 @@
 #include "ShaderRegistry.h"
 #include "DescriptorHeapPool.h"
 #include "ModelRegistry.h"
+#include "ModelLoadSetting.h"
+#include "EncryptAssetMain.h"
+#include "SampleScene.h"
 
-#include "GameObject.h"
-#include "Component.h"
-#include "Scene.h"
-#include "LayeredGPSOWrapper.h"
-
+// Width of window size
 const UINT WINDOW_WIDTH = 1920;
+// Height of window size
 const UINT WINDOW_HEIGHT = 1080;
 
-class RotateComponent : public ACComponent {
-public:
-    RotateComponent(CGameObject* obj, Vector3f axis, float speed) : ACComponent(obj), m_axis(axis), m_speed(speed) {}
-
-    void Start() {
-
-    }
-
-    void Update() {
-        Quaternionf rotate = m_gameObj->GetTransform().rotation;
-        rotate.AngleAxis(m_speed * (float)CAppClock::GetMain().GetDeltaTime(), m_axis);
-        m_gameObj->SetRotation(rotate);
-    }
-private:
-    Vector3f m_axis;
-    float m_speed;
-};
-
-class LerpTestComponent : public ACComponent {
-public:
-    LerpTestComponent(CGameObject* obj, Quaternionf a, Quaternionf b) : ACComponent(obj), m_start(a), m_end(b) {}
-
-    void Start() { m_t = 0.0f; m_sign = 1.0f; m_startV = m_gameObj->GetTransform().pos; m_endV = m_startV + Vector3f(0.0f, 3.0f, 0.0f); }
-
-    void Update() {
-        m_t += (float)CAppClock::GetMain().GetDeltaTime() * 0.5f * m_sign;
-        if (m_t > 1.0f) {
-            m_sign = -m_sign;
-            m_t = 1.0f;
-        }
-        else if (m_t < 0.0f) {
-            m_sign = -m_sign;
-            m_t = 0.0f;
-        }
-
-        m_gameObj->SetPos(Utl::Math::Lerp(m_startV, m_endV, m_t));
-        m_gameObj->SetRotation(Utl::Math::Slerp(m_start, m_end, m_t));
-    }
-
-private:
-    float m_t;
-    float m_sign;
-    Quaternionf m_start;
-    Quaternionf m_end;
-    Vector3f m_startV;
-    Vector3f m_endV;
-};
-
-class CAnimComponent : public ACComponent {
-public:
-    using ACComponent::ACComponent;
-
-    void Start() {
-        m_model = m_gameObj->GetComponent<CSkeletalModel>();
-
-        CDynamicModelController* modelData = m_model->GetController();
-
-        m_animNo = 0;
-
-        modelData->Play(m_animNo, true);
-        //m_model->GetUniqueData()->animes[0].speed = 0.25f;
-    }
-
-    void Update() {
-        if (CInputSystem::GetMain().IsKeyDown('K')) {
-            CDynamicModelController* modelData = m_model->GetController();
-
-            m_animNo = (m_animNo + 1) % 2;
-            modelData->Play(m_animNo, true);
-        }
-
-        if (CInputSystem::GetMain().IsKeyDown('N')) {
-            CDynamicModelController* modelData = m_model->GetController();
-            modelData->BindPose();
-        }
-    }
-
-private:
-    CWeakPtr<CSkeletalModel> m_model;
-    ModelInfo::AnimID m_animNo;
-};
-
-class CTestScene : public ACScene {
-public:
-    void Start() {
-        // Create dsv
-        ACRenderTarget* backBuffer = CSwapChain::GetAny().GetBackBuffer();
-        m_dsv2D.Create(DXGI_FORMAT_D32_FLOAT, backBuffer->GetWidth(), backBuffer->GetHeight());
-        m_dsv3D.Create(DXGI_FORMAT_D32_FLOAT, backBuffer->GetWidth(), backBuffer->GetHeight());
-
-        // Create gpso3DModel
-        {
-            LayeredGPSOSetting standardSetting({ GraphicsComponentType::BasicModel, GraphicsComponentType::TexShape });
-            standardSetting.defaultSetting.vs = CShaderRegistry::GetAny().GetVS(VertexShaderType::Standard3D);
-            standardSetting.defaultSetting.ps = CShaderRegistry::GetAny().GetPS(PixelShaderType::StandardTex);
-            standardSetting.defaultSetting.rtvFormats.push_back(std::make_pair(DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, Gpso::BlendStateSetting::Alpha));
-            standardSetting.defaultSetting.rasterizerState.cullMode = D3D12_CULL_MODE_BACK;
-            standardSetting.defaultSetting.depth.type = Gpso::DepthTestType::ReadWrite;
-            {
-                auto setting = standardSetting.AddOverrideSetting({ GraphicsComponentType::SkeletalModel });
-                setting->vs = CShaderRegistry::GetAny().GetVS(VertexShaderType::Standard3DAnim);
-            }
-            {
-                auto setting = standardSetting.AddOverrideSetting({ GraphicsComponentType::ColorShape });
-                setting->ps = CShaderRegistry::GetAny().GetPS(PixelShaderType::StandardColor);
-            }
-            {
-                auto setting = standardSetting.AddOverrideSetting({ GraphicsComponentType::Sprite3D, GraphicsComponentType::Billboard });
-                setting->vs = CShaderRegistry::GetAny().GetVS(VertexShaderType::Standard3DSprite);
-                setting->rasterizerState = Gpso::RasterizerStateSetting();
-                setting->rasterizerState->cullMode = D3D12_CULL_MODE_NONE;
-            }
-            m_standardGpso.Create(this, L"Standard GPSO", standardSetting, { GraphicsLayer::Standard });
-        }
-
-        // Create gpso2D
-        {
-            Gpso::GPSOSetting gpsoSetting2D;
-            gpsoSetting2D.vs = CShaderRegistry::GetAny().GetVS(VertexShaderType::Standard2DSprite);
-            gpsoSetting2D.ps = CShaderRegistry::GetAny().GetPS(PixelShaderType::StandardTex);
-            gpsoSetting2D.rtvFormats.push_back(std::make_pair(DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, Gpso::BlendStateSetting::Alpha));
-            gpsoSetting2D.rasterizerState.cullMode = D3D12_CULL_MODE_BACK;
-            gpsoSetting2D.depth.type = Gpso::DepthTestType::ReadWrite;
-            m_gpso2D.Create(this, L"UI GPSO", gpsoSetting2D, { GraphicsLayer::UI }, { GraphicsComponentType::SpriteUI });
-        }
-
-        // UI obj
-        auto ui1 = CreateGameObject<CGameObject>(Transformf(Vector3f(80.0f, -50.0f, 0.0f), Vector3f::Ones(), Utl::DEG_2_RAD * Vector3f(0.0f, 0.0f, 0.0f)));
-        ui1->AddComponent<CSpriteUI>(GraphicsLayer::UI, L"Texture/textest200x200.png");
-        ui1->AddComponent<RotateComponent>(Vector3f(0.0f, 0.0f, 1.0f).GetNormalize(), 1.5f);
-        // UI obj
-        auto ui2 = CreateGameObject<CGameObject>(Transformf(Vector3f(70.0f, -40.0f, 0.5f), Vector3f::Ones(), Utl::DEG_2_RAD * Vector3f(0.0f, 0.0f, 0.0f)));
-        ui2->AddComponent<CSpriteUI>(GraphicsLayer::UI, L"Texture/textest200x200.png");
-        ui2->AddComponent<RotateComponent>(Vector3f(0.0f, 0.0f, 1.0f).GetNormalize(), 1.0f);
-
-        // Sprite obj
-        auto sprite1 = CreateGameObject<CGameObject>(Transformf(Vector3f(0.0f, 0.0f, 0.0f), Vector3f::Ones(), Utl::DEG_2_RAD * Vector3f(0.0f, 20.0f, 0.0f)));
-        sprite1->AddComponent<CSprite3D>(GraphicsLayer::Standard, L"Texture/apollo11.png");
-        sprite1->AddComponent<RotateComponent>(Vector3f(1.0f, 0.0f, 0.0f).GetNormalize(), 1.0f);
-        //
-        auto sprite2 = CreateGameObject<CGameObject>(Transformf(Vector3f(0.5f, 0.0f, 0.0f), Vector3f::Ones(), Utl::DEG_2_RAD * Vector3f(45.0f, 0.0f, 0.0f)));
-        sprite2->AddComponent<CSprite3D>(GraphicsLayer::Standard, L"Texture/textest200x200.png");
-        sprite2->AddComponent<RotateComponent>(Vector3f(0.0f, 1.0f, 0.0f).GetNormalize(), 3.0f);
-
-        // Billboard obj
-        auto billboard = CreateGameObject<CGameObject>(Transformf(Vector3f(0.0f, -1.5f, 0.0f), Vector3f::Ones(), Utl::DEG_2_RAD * Vector3f(0.0f, 0.0f, 0.0f)));
-        billboard->AddComponent<CBillboard>(GraphicsLayer::Standard, L"Texture/apollo11.png");
-
-        // Box
-        {
-            auto box = CreateGameObject<CGameObject>(Transformf(Vector3f(0.0f, 0.0f, 0.0f), Vector3f::Ones(), Vector3f::Zero()));
-            box->AddComponent<CTexShape>(GraphicsLayer::Standard, ShapeKind::Box, L"Texture/textest200x200.png");
-            box->AddComponent<RotateComponent>(Vector3f(1.0f, 1.0f, 0.0f).GetNormalize(), 1.0f);
-        }
-
-        // Capsule
-        {
-            auto capsule = CreateGameObject<CGameObject>(Transformf(Vector3f(5.0f, 0.0f, 0.0f), Vector3f::Ones(), Vector3f::Zero()));
-            capsule->AddComponent<CColorOnlyShape>(GraphicsLayer::Standard, ShapeKind::Capsule, Colorf(1.0f, 0.0f, 0.0f, 1.0f));
-            capsule->AddComponent<RotateComponent>(Vector3f(1.0f, 1.0f, 0.0f).GetNormalize(), 1.0f);
-        }
-
-        auto desk = CreateGameObject<CGameObject>(Transformf(Vector3f(-2.0f, 0.0f, 0.0f), Vector3f::Ones(), Vector3f::Zero()));
-        desk->AddComponent<CBasicModel>(GraphicsLayer::Standard, L"desk/desk.fbx");
-        desk->AddComponent<RotateComponent>(Vector3f(0.0f, 1.0f, 0.0f).GetNormalize(), 3.0f);
-        
-        for (int i = 0; i < 20; ++i) {
-            auto uwan = CreateGameObject<CGameObject>(Transformf(Vector3f((float)i - 10.0f, -1.0f, 5.0f), Vector3f::Ones(), Utl::DEG_2_RAD * Vector3f(0.0f, (float)i * 30.0f, 0.0f)));
-            uwan->AddComponent<CSkeletalModel>(GraphicsLayer::Standard, L"unitychan/unitychan.fbx");
-            uwan->AddComponent<CAnimComponent>();
-            uwan->AddComponent<RotateComponent>(Vector3f(0.0f, 1.0f, 0.0f).GetNormalize(), 3.0f);
-            //uwan->AddComponent<LerpTestComponent>(
-            //    Quaternionf(Utl::DEG_2_RAD * Vector3f(0.0f, 0.0f, 0.0f)),
-            //    Quaternionf(Utl::DEG_2_RAD * Vector3f((float)i * 30, 180.0f, 0.0f)));
-        }
-
-        // Camera obj
-        auto camera = CreateGameObject<CGameObject>(Transformf(Vector3f(0.0f, 0.0f, -5.0f)));
-        camera->AddComponent<CCameraComponent>(L"Main camera");
-        camera->AddComponent<RotateComponent>(Vector3f(0.0f, 1.0f, 0.0f), 0.1f);
-    }
-
-    void Draw() {
-        ACRenderTarget* rtv = CSwapChain::GetAny().GetBackBuffer();
-
-        m_dsv3D.Clear();
-        m_dsv2D.Clear();
-
-        Colorf clearColor(0.4f, 0.4f, 0.8f, 1.0f);
-        rtv->Clear(clearColor);
-        rtv->Apply(&m_dsv3D);
-
-        m_standardGpso.SetCommand();
-
-        rtv->Apply(&m_dsv2D);
-
-        m_gpso2D.SetCommand();
-    }
-private:
-    CLayeredGPSOWrapper m_standardGpso;
-    CGraphicsPipelineState m_gpso2D;
-    CDepthStencil m_dsv3D;
-    CDepthStencil m_dsv2D;
-};
-
-class CTestScene2 : public ACScene {
-public:
-    void Start() {
-        // Create gpso
-        Gpso::GPSOSetting gpsoSetting;
-        gpsoSetting.vs = CShaderRegistry::GetAny().GetVS(VertexShaderType::Standard2DSprite);
-        gpsoSetting.ps = CShaderRegistry::GetAny().GetPS(PixelShaderType::StandardTex);
-        gpsoSetting.rtvFormats.push_back(std::make_pair(DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, Gpso::BlendStateSetting::Alpha));
-        gpsoSetting.rasterizerState.cullMode = D3D12_CULL_MODE_NONE;
-        m_gpso.Create(this, L"All objects GPSO", gpsoSetting, { GraphicsLayer::UI }, { GraphicsComponentType::SpriteUI });
-
-        // Sprite obj
-        auto obj = CreateGameObject<CGameObject>(Transformf(Vector3f(-50.0f, 0.0f, 0.0f), Vector3f(1.0f, 1.0f, 1.0f), Vector3f(Utl::DEG_2_RAD * 0.0f, Utl::DEG_2_RAD * 0.0f, Utl::DEG_2_RAD * 0.0f)));
-        obj->AddComponent<CSpriteUI>(GraphicsLayer::UI, L"Texture/textest200x200.png");
-
-        // Camera obj
-        auto camera = CreateGameObject<CGameObject>(Transformf(Vector3f(0.0f, 0.0f, 5.0f)));
-        camera->AddComponent<CCameraComponent>(L"Main camera");
-    }
-
-    void Draw() {
-        ACRenderTarget* rtv = CSwapChain::GetAny().GetBackBuffer();
-
-        Colorf clearColor(0.2f, 0.2f, 0.2f, 1.0f);
-        rtv->Clear(clearColor);
-        rtv->Apply(nullptr);
-
-        m_gpso.SetCommand();
-    }
-private:
-    CGraphicsPipelineState m_gpso;
-};
-
-bool g_isScene2 = false;
-CUniquePtrWeakable<CGraphicsObjectAsset> asset;
-
+// Window procedure
 LRESULT WindowProcedure(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) {
     switch (msg) {
     case WM_KEYDOWN:
@@ -278,16 +38,6 @@ LRESULT WindowProcedure(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) {
         case VK_ESCAPE:
             PostQuitMessage(0);
             return 0;
-            break;
-        case VK_SPACE:
-            if (!g_isScene2) {
-                CSceneRegistry::GetMain().SetNextScene<CTestScene2>();
-                g_isScene2 = true;
-            }
-            else {
-                CSceneRegistry::GetMain().SetNextScene<CTestScene>();
-                g_isScene2 = false;
-            }
             break;
         }
         break;
@@ -361,22 +111,17 @@ void ApplicationMain() {
 
     // Initialize the static shape mesh class
     CShapeMesh::Initialize();
-    
-    CTextureRegistry::GetMain().LoadPak(L"Assets/textures");
 
-    CModelRegistry::GetMain().AddModelLoadDesc(L"unitychan/unitychan.fbx", ModelInfo::Load::ModelDesc(0.025f, ModelInfo::Load::CoordinateSystem::Standard, 1.0f));
-    CModelRegistry::GetMain().AddModelLoadDesc(L"desk/desk.fbx", ModelInfo::Load::ModelDesc(0.025f, ModelInfo::Load::CoordinateSystem::Blender));
+    // Load textures
+    CTextureRegistry::GetMain().LoadPak(PAK_FILE_TEXTURES);
 
-    CModelRegistry::GetMain().AddAnimLoadDesc(L"unitychan/jump.fbx", ModelInfo::Load::AnimDesc(1.0f));
-    CModelRegistry::GetMain().AddAnimLoadDesc(L"unitychan/run.fbx", ModelInfo::Load::AnimDesc(1.0f, true));
+    // Perform setting and load models and animations
+    ModelLoadSetting();
+    CModelRegistry::GetMain().LoadModelPak(PAK_FILE_MODELS);
+    CModelRegistry::GetMain().LoadAnimPak(PAK_FILE_ANIMATIONS);
 
-    CModelRegistry::GetMain().AddAnimToAnimSetting(L"unitychan/jump.fbx", L"unitychan/run.fbx", ModelInfo::InterpolationSetting(5.0f));
-    CModelRegistry::GetMain().AddAnimToAnimSetting(L"unitychan/run.fbx", L"unitychan/jump.fbx", ModelInfo::InterpolationSetting(0.3f));
-
-    CModelRegistry::GetMain().LoadModelPak(L"Assets/models");
-    CModelRegistry::GetMain().LoadAnimPak(L"Assets/anims");
-
-    CSceneRegistry::GetMain().Initialize<CTestScene>();
+    // Set first scene
+    CSceneRegistry::GetMain().Initialize<CSampleScene>();
 
     // Main loop
     MSG msg = {};

--- a/MakinoProject00/MakinoProject00/AssetNameDefine.h
+++ b/MakinoProject00/MakinoProject00/AssetNameDefine.h
@@ -1,0 +1,30 @@
+/**
+ * @file   AssetNameDefine.h
+ * @brief  This file handles header file defining the asset names.
+ * 
+ * @author Shodai Makino
+ * @date   2024/1/11
+ */
+
+#ifndef __ASSET_NAME_DEFINE_H__
+#define __ASSET_NAME_DEFINE_H__
+
+/** @brief Texture name for test image */
+const std::wstring TEX_NAME_TEST = L"Texture/textest200x200.png";
+/** @brief Texture name for test image 2 */
+const std::wstring TEX_NAME_TEST2 = L"Texture/apollo11.png";
+
+
+/** @brief Model name for Unity-chan */
+const std::wstring MODEL_NAME_UNITYCHAN = L"unitychan/unitychan.fbx";
+/** @brief Model name for desk */
+const std::wstring MODEL_NAME_DESK = L"desk/desk.fbx";
+
+
+/** @brief Animation name for jump animation of Unity-chan */
+const std::wstring ANIM_NAME_UNITYCHAN_JUMP = L"unitychan/jump.fbx";
+/** @brief Animation name for run animation of Unity-chan */
+const std::wstring ANIM_NAME_UNITYCHAN_RUN = L"unitychan/run.fbx";
+
+#endif // !__ASSET_NAME_DEFINE_H__
+

--- a/MakinoProject00/MakinoProject00/EncryptAssetMain.cpp
+++ b/MakinoProject00/MakinoProject00/EncryptAssetMain.cpp
@@ -8,13 +8,13 @@
 // Main function for encrypting assets
 void EncryptAssetMain() {
     // Create .pak file for texture
-    AssetCrypter::CreatePakFile(L"Assets/textures", { ".png", ".jpg", ".tga" });
+    AssetCrypter::CreatePakFile(PAK_FILE_TEXTURES, { ".png", ".jpg", ".tga" });
 
     // Create .pak file for model
-    AssetCrypter::CreatePakFile(L"Assets/models", { ".fbx", }, Utl::Str::wstring2String(MODELASSET_DIR));
+    AssetCrypter::CreatePakFile(PAK_FILE_MODELS, { ".fbx", }, Utl::Str::wstring2String(MODELASSET_DIR));
 
     // Create .pak file for animation
-    AssetCrypter::CreatePakFile(L"Assets/anims", { ".fbx", }, Utl::Str::wstring2String(ANIMASSET_DIR));
+    AssetCrypter::CreatePakFile(PAK_FILE_ANIMATIONS, { ".fbx", }, Utl::Str::wstring2String(ANIMASSET_DIR));
 
     // Output successful message
     std::wcout << L"Successful encryption of assets!" << std::endl;

--- a/MakinoProject00/MakinoProject00/EncryptAssetMain.h
+++ b/MakinoProject00/MakinoProject00/EncryptAssetMain.h
@@ -9,6 +9,13 @@
 #ifndef __ENCRYPT_ASSET_MAIN_H__
 #define __ENCRYPT_ASSET_MAIN_H__
 
+/** @brief Name of .pak file for textures */
+const std::wstring PAK_FILE_TEXTURES = L"Assets/textures";
+/** @brief Name of .pak file for models */
+const std::wstring PAK_FILE_MODELS = L"Assets/models";
+/** @brief Name of .pak file for animations */
+const std::wstring PAK_FILE_ANIMATIONS = L"Assets/anims";
+
 #ifdef _ENCRYPT_ASSET
 /** @brief Main function for encrypting assets */
 void EncryptAssetMain();

--- a/MakinoProject00/MakinoProject00/LayeredGPSOWrapper.cpp
+++ b/MakinoProject00/MakinoProject00/LayeredGPSOWrapper.cpp
@@ -64,3 +64,8 @@ void CLayeredGPSOWrapper::EndFrameProcess() {
         it.EndFrameProcess();
     }
 }
+
+// Function that do nothing to avoid accidental calls from the outside
+void CLayeredGPSOWrapperPrefab::Create(ACScene* scene, const std::wstring gpsoName, const LayeredGPSOSetting& setting, std::initializer_list<GraphicsLayer> useLayers) {
+    throw Utl::Error::CFatalError(L"This is function that does nothing");
+}

--- a/MakinoProject00/MakinoProject00/LayeredGPSOWrapper.h
+++ b/MakinoProject00/MakinoProject00/LayeredGPSOWrapper.h
@@ -70,7 +70,7 @@ public:
     CLayeredGPSOWrapper();
 
     /** @brief Destructor */
-    virtual ~CLayeredGPSOWrapper() = default;
+    ~CLayeredGPSOWrapper() = default;
 
     /**
        @brief Create graphics pipeline states
@@ -79,7 +79,7 @@ public:
        @param setting Graphics pipeline state setting
        @param useLayer Layers handled by this GPSO (Draw in the order passed)
     */
-    void Create(ACScene* scene, const std::wstring gpsoName, const LayeredGPSOSetting& setting, std::initializer_list<GraphicsLayer> useLayers);
+    virtual void Create(ACScene* scene, const std::wstring gpsoName, const LayeredGPSOSetting& setting, std::initializer_list<GraphicsLayer> useLayers);
 
     /**
        @brief Call 'SetCommand' function from GPSOs wrapped this class
@@ -99,6 +99,21 @@ private:
     /** @brief The name of this gpso wrapper. Used for debbuging */
     std::wstring m_name;
 #endif // _DEBUG
+};
+
+/** @brief Abstract class for prefab of CLayeredGPSOWrapper */
+class CLayeredGPSOWrapperPrefab : public CLayeredGPSOWrapper {
+public:
+    /**
+       @brief Function for creating a prefab of a gpso wrapper
+       @param scene The scene where this GPSO exists
+    */
+    virtual void Prefab(ACScene* scene) = 0;
+
+    /**
+       @brief Function that do nothing to avoid accidental calls from the outside
+    */
+    void Create(ACScene* scene, const std::wstring gpsoName, const LayeredGPSOSetting& setting, std::initializer_list<GraphicsLayer> useLayers) override;
 };
 
 #endif // !__LAYERED_GPSO_WRAPPER_H__

--- a/MakinoProject00/MakinoProject00/MakinoProject00.vcxproj
+++ b/MakinoProject00/MakinoProject00/MakinoProject00.vcxproj
@@ -69,6 +69,7 @@
     <ClCompile Include="MeshBuffer.cpp" />
     <ClCompile Include="Model.cpp" />
     <ClCompile Include="LoadedModelInfo.cpp" />
+    <ClCompile Include="ModelLoadSetting.cpp" />
     <ClCompile Include="ModelRegistry.cpp" />
     <ClCompile Include="Precompile.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
@@ -82,6 +83,8 @@
     </ClCompile>
     <ClCompile Include="ReleaseSingleton.cpp" />
     <ClCompile Include="RenderTarget.cpp" />
+    <ClCompile Include="SampleComponent.cpp" />
+    <ClCompile Include="SampleScene.cpp" />
     <ClCompile Include="Scene.cpp" />
     <ClCompile Include="SceneRegistry.cpp" />
     <ClCompile Include="Shader.cpp" />
@@ -89,6 +92,7 @@
     <ClCompile Include="ShaderRegistry.cpp" />
     <ClCompile Include="Shape.cpp" />
     <ClCompile Include="Sprite.cpp" />
+    <ClCompile Include="StandardGPSOWrapper.cpp" />
     <ClCompile Include="StaticCbOrthographicMat.cpp" />
     <ClCompile Include="StaticCbVPMat.cpp" />
     <ClCompile Include="StaticResourceRegistry.cpp" />
@@ -178,6 +182,7 @@
     <ClInclude Include="ApplicationError.h" />
     <ClInclude Include="ApplicationMain.h" />
     <ClInclude Include="AssetCrypter.h" />
+    <ClInclude Include="AssetNameDefine.h" />
     <ClInclude Include="CallbackSystem.h" />
     <ClInclude Include="Camera.h" />
     <ClInclude Include="CameraRegistry.h" />
@@ -216,12 +221,15 @@
     <ClInclude Include="MeshBuffer.h" />
     <ClInclude Include="Model.h" />
     <ClInclude Include="LoadedModelInfo.h" />
+    <ClInclude Include="ModelLoadSetting.h" />
     <ClInclude Include="ModelRegistry.h" />
     <ClInclude Include="Precompile.h" />
     <ClInclude Include="ReleaseSingleton.h" />
     <ClInclude Include="RenderTarget.h" />
     <ClInclude Include="Resource\Resource.h" />
     <ClInclude Include="AbstractSbAllocator.h" />
+    <ClInclude Include="SampleComponent.h" />
+    <ClInclude Include="SampleScene.h" />
     <ClInclude Include="Scene.h" />
     <ClInclude Include="SceneRegistry.h" />
     <ClInclude Include="Shader.h" />
@@ -232,6 +240,7 @@
     <ClInclude Include="Application.h" />
     <ClInclude Include="Sprite.h" />
     <ClInclude Include="StableHandleVector.h" />
+    <ClInclude Include="StandardGPSOWrapper.h" />
     <ClInclude Include="StaticCbAllocator.h" />
     <ClInclude Include="StaticCbOrthographicMat.h" />
     <ClInclude Include="StaticCbVPMat.h" />

--- a/MakinoProject00/MakinoProject00/MakinoProject00.vcxproj.filters
+++ b/MakinoProject00/MakinoProject00/MakinoProject00.vcxproj.filters
@@ -94,14 +94,8 @@
     <Filter Include="ヘッダー ファイル\Framework\Standard">
       <UniqueIdentifier>{20698230-7090-488f-b8dd-0ed55dabb09d}</UniqueIdentifier>
     </Filter>
-    <Filter Include="ヘッダー ファイル\Framework\Standard\StandardComponent">
-      <UniqueIdentifier>{8f128ec5-3249-4053-8e90-63c16e86d249}</UniqueIdentifier>
-    </Filter>
     <Filter Include="ソース ファイル\Framework\Standard">
       <UniqueIdentifier>{4e66886c-c582-4902-ae96-e3065ecaab27}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="ソース ファイル\Framework\Standard\StandardComponent">
-      <UniqueIdentifier>{4e4a9f34-453d-4f22-af22-31a17c6a2c1a}</UniqueIdentifier>
     </Filter>
     <Filter Include="ソース ファイル\Framework\Graphics\Resource">
       <UniqueIdentifier>{71ca4d56-7867-49c5-ad32-e8a70157335d}</UniqueIdentifier>
@@ -114,12 +108,6 @@
     </Filter>
     <Filter Include="ヘッダー ファイル\Framework\Graphics\Resource\Mesh">
       <UniqueIdentifier>{5b3a3b35-eefe-4bc4-ba0b-f09acfa76793}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="ヘッダー ファイル\Framework\Standard\StandardResource">
-      <UniqueIdentifier>{c3f725d3-7fa7-4b94-b75e-c9683c37cabb}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="ソース ファイル\Framework\Standard\StandardResource">
-      <UniqueIdentifier>{96eec525-14a7-49c3-ba2f-f5c67977d73e}</UniqueIdentifier>
     </Filter>
     <Filter Include="ソース ファイル\Crypter">
       <UniqueIdentifier>{eee714cd-0263-4da4-95e5-b527fcf94022}</UniqueIdentifier>
@@ -150,6 +138,24 @@
     </Filter>
     <Filter Include="リソース ファイル\Resource">
       <UniqueIdentifier>{a3f35066-9196-4eae-99ed-68eb22d8339e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ヘッダー ファイル\Framework\Standard\Component">
+      <UniqueIdentifier>{8f128ec5-3249-4053-8e90-63c16e86d249}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ヘッダー ファイル\Framework\Standard\Resource">
+      <UniqueIdentifier>{c3f725d3-7fa7-4b94-b75e-c9683c37cabb}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ソース ファイル\Framework\Standard\Component">
+      <UniqueIdentifier>{4e4a9f34-453d-4f22-af22-31a17c6a2c1a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ソース ファイル\Framework\Standard\Resource">
+      <UniqueIdentifier>{96eec525-14a7-49c3-ba2f-f5c67977d73e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ソース ファイル\Framework\Standard\GPSO">
+      <UniqueIdentifier>{a953010d-504f-43e0-8efa-1f8edf93eba7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ヘッダー ファイル\Framework\Standard\GPSO">
+      <UniqueIdentifier>{b3347a93-cb42-4c4c-95ed-8093d78eecd5}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -247,22 +253,22 @@
       <Filter>ソース ファイル\Framework\SystemDesign</Filter>
     </ClCompile>
     <ClCompile Include="StaticCbVPMat.cpp">
-      <Filter>ソース ファイル\Framework\Standard\StandardResource</Filter>
+      <Filter>ソース ファイル\Framework\Standard\Resource</Filter>
     </ClCompile>
     <ClCompile Include="DynamicCbWorldMat.cpp">
-      <Filter>ソース ファイル\Framework\Standard\StandardResource</Filter>
+      <Filter>ソース ファイル\Framework\Standard\Resource</Filter>
     </ClCompile>
     <ClCompile Include="CameraRegistry.cpp">
       <Filter>ソース ファイル\Framework\SystemDesign</Filter>
     </ClCompile>
     <ClCompile Include="Camera.cpp">
-      <Filter>ソース ファイル\Framework\Standard\StandardComponent</Filter>
+      <Filter>ソース ファイル\Framework\Standard\Component</Filter>
     </ClCompile>
     <ClCompile Include="StaticCbOrthographicMat.cpp">
-      <Filter>ソース ファイル\Framework\Standard\StandardResource</Filter>
+      <Filter>ソース ファイル\Framework\Standard\Resource</Filter>
     </ClCompile>
     <ClCompile Include="Sprite.cpp">
-      <Filter>ソース ファイル\Framework\Standard\StandardComponent</Filter>
+      <Filter>ソース ファイル\Framework\Standard\Component</Filter>
     </ClCompile>
     <ClCompile Include="SceneRegistry.cpp">
       <Filter>ソース ファイル\Framework\SystemDesign</Filter>
@@ -280,7 +286,7 @@
       <Filter>ソース ファイル\Framework\Graphics\Registry</Filter>
     </ClCompile>
     <ClCompile Include="DynamicSbAnimMat.cpp">
-      <Filter>ソース ファイル\Framework\Standard\StandardResource</Filter>
+      <Filter>ソース ファイル\Framework\Standard\Resource</Filter>
     </ClCompile>
     <ClCompile Include="DynamicSbRegistry.cpp">
       <Filter>ソース ファイル\Framework\Graphics\Registry</Filter>
@@ -325,16 +331,28 @@
       <Filter>ソース ファイル\Framework\Graphics\Registry</Filter>
     </ClCompile>
     <ClCompile Include="Model.cpp">
-      <Filter>ソース ファイル\Framework\Standard\StandardComponent</Filter>
+      <Filter>ソース ファイル\Framework\Standard\Component</Filter>
     </ClCompile>
     <ClCompile Include="LoadedModelInfo.cpp">
       <Filter>ソース ファイル\Framework\Graphics\Generic</Filter>
     </ClCompile>
     <ClCompile Include="Shape.cpp">
-      <Filter>ソース ファイル\Framework\Standard\StandardComponent</Filter>
+      <Filter>ソース ファイル\Framework\Standard\Component</Filter>
     </ClCompile>
     <ClCompile Include="DynamicCbColor.cpp">
-      <Filter>ソース ファイル\Framework\Standard\StandardResource</Filter>
+      <Filter>ソース ファイル\Framework\Standard\Resource</Filter>
+    </ClCompile>
+    <ClCompile Include="StandardGPSOWrapper.cpp">
+      <Filter>ソース ファイル\Framework\Standard\GPSO</Filter>
+    </ClCompile>
+    <ClCompile Include="SampleScene.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
+    <ClCompile Include="SampleComponent.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
+    <ClCompile Include="ModelLoadSetting.cpp">
+      <Filter>ソース ファイル</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -487,25 +505,25 @@
       <Filter>ヘッダー ファイル\Framework\SystemDesign</Filter>
     </ClInclude>
     <ClInclude Include="StaticCbVPMat.h">
-      <Filter>ヘッダー ファイル\Framework\Standard\StandardResource</Filter>
+      <Filter>ヘッダー ファイル\Framework\Standard\Resource</Filter>
     </ClInclude>
     <ClInclude Include="DynamicCbWorldMat.h">
-      <Filter>ヘッダー ファイル\Framework\Standard\StandardResource</Filter>
+      <Filter>ヘッダー ファイル\Framework\Standard\Resource</Filter>
     </ClInclude>
     <ClInclude Include="CameraRegistry.h">
       <Filter>ヘッダー ファイル\Framework\SystemDesign</Filter>
     </ClInclude>
     <ClInclude Include="Camera.h">
-      <Filter>ヘッダー ファイル\Framework\Standard\StandardComponent</Filter>
+      <Filter>ヘッダー ファイル\Framework\Standard\Component</Filter>
     </ClInclude>
     <ClInclude Include="Sprite.h">
-      <Filter>ヘッダー ファイル\Framework\Standard\StandardComponent</Filter>
+      <Filter>ヘッダー ファイル\Framework\Standard\Component</Filter>
     </ClInclude>
     <ClInclude Include="DynamicCbAllocator.h">
       <Filter>ヘッダー ファイル\Framework\Graphics\Resource\ConstantBuffer</Filter>
     </ClInclude>
     <ClInclude Include="StaticCbOrthographicMat.h">
-      <Filter>ヘッダー ファイル\Framework\Standard\StandardResource</Filter>
+      <Filter>ヘッダー ファイル\Framework\Standard\Resource</Filter>
     </ClInclude>
     <ClInclude Include="SceneRegistry.h">
       <Filter>ヘッダー ファイル\Framework\SystemDesign</Filter>
@@ -553,7 +571,7 @@
       <Filter>ヘッダー ファイル\Framework\Graphics\Resource</Filter>
     </ClInclude>
     <ClInclude Include="DynamicSbAnimMat.h">
-      <Filter>ヘッダー ファイル\Framework\Standard\StandardResource</Filter>
+      <Filter>ヘッダー ファイル\Framework\Standard\Resource</Filter>
     </ClInclude>
     <ClInclude Include="DynamicSbRegistry.h">
       <Filter>ヘッダー ファイル\Framework\Graphics\Registry</Filter>
@@ -601,16 +619,31 @@
       <Filter>ヘッダー ファイル\Framework\Utility</Filter>
     </ClInclude>
     <ClInclude Include="Model.h">
-      <Filter>ヘッダー ファイル\Framework\Standard\StandardComponent</Filter>
+      <Filter>ヘッダー ファイル\Framework\Standard\Component</Filter>
     </ClInclude>
     <ClInclude Include="LoadedModelInfo.h">
       <Filter>ヘッダー ファイル\Framework\Graphics\Generic</Filter>
     </ClInclude>
     <ClInclude Include="DynamicCbColor.h">
-      <Filter>ヘッダー ファイル\Framework\Standard\StandardResource</Filter>
+      <Filter>ヘッダー ファイル\Framework\Standard\Resource</Filter>
     </ClInclude>
     <ClInclude Include="Shape.h">
-      <Filter>ヘッダー ファイル\Framework\Standard\StandardComponent</Filter>
+      <Filter>ヘッダー ファイル\Framework\Standard\Component</Filter>
+    </ClInclude>
+    <ClInclude Include="StandardGPSOWrapper.h">
+      <Filter>ヘッダー ファイル\Framework\Standard\GPSO</Filter>
+    </ClInclude>
+    <ClInclude Include="SampleScene.h">
+      <Filter>ヘッダー ファイル</Filter>
+    </ClInclude>
+    <ClInclude Include="SampleComponent.h">
+      <Filter>ヘッダー ファイル</Filter>
+    </ClInclude>
+    <ClInclude Include="AssetNameDefine.h">
+      <Filter>ヘッダー ファイル</Filter>
+    </ClInclude>
+    <ClInclude Include="ModelLoadSetting.h">
+      <Filter>ヘッダー ファイル</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/MakinoProject00/MakinoProject00/ModelLoadSetting.cpp
+++ b/MakinoProject00/MakinoProject00/ModelLoadSetting.cpp
@@ -1,0 +1,18 @@
+#include "ModelLoadSetting.h"
+#include "AssetNameDefine.h"
+#include "ModelRegistry.h"
+
+// Performs setting when loading models
+void ModelLoadSetting() {
+    // Model setting
+    CModelRegistry::GetMain().AddModelLoadDesc(MODEL_NAME_UNITYCHAN, ModelInfo::Load::ModelDesc(0.025f, ModelInfo::Load::CoordinateSystem::Standard, 1.0f));
+    CModelRegistry::GetMain().AddModelLoadDesc(MODEL_NAME_DESK, ModelInfo::Load::ModelDesc(0.025f, ModelInfo::Load::CoordinateSystem::Blender));
+
+    // Animation setting
+    CModelRegistry::GetMain().AddAnimLoadDesc(ANIM_NAME_UNITYCHAN_JUMP, ModelInfo::Load::AnimDesc(1.0f));
+    CModelRegistry::GetMain().AddAnimLoadDesc(ANIM_NAME_UNITYCHAN_RUN, ModelInfo::Load::AnimDesc(1.0f, true));
+
+    // Animation interpolation setting
+    CModelRegistry::GetMain().AddAnimToAnimSetting(ANIM_NAME_UNITYCHAN_JUMP, ANIM_NAME_UNITYCHAN_RUN, ModelInfo::InterpolationSetting(5.0f));
+    CModelRegistry::GetMain().AddAnimToAnimSetting(ANIM_NAME_UNITYCHAN_RUN, ANIM_NAME_UNITYCHAN_JUMP, ModelInfo::InterpolationSetting(0.3f));
+}

--- a/MakinoProject00/MakinoProject00/ModelLoadSetting.h
+++ b/MakinoProject00/MakinoProject00/ModelLoadSetting.h
@@ -1,0 +1,15 @@
+/**
+ * @file   ModelLoadSetting.h
+ * @brief  This file performs setting when loading models.
+ * 
+ * @author Shodai Makino
+ * @date   2024/1/11
+ */
+
+#ifndef __MODEL_LOAD_SETTING_H__
+#define __MODEL_LOAD_SETTING_H__
+
+/** @brief Performs setting when loading models */
+void ModelLoadSetting();
+
+#endif // !__MODEL_LOAD_SETTING_H__

--- a/MakinoProject00/MakinoProject00/SampleComponent.cpp
+++ b/MakinoProject00/MakinoProject00/SampleComponent.cpp
@@ -1,0 +1,35 @@
+#include "SampleComponent.h"
+#include "GameObject.h"
+#include "ApplicationClock.h"
+#include "InputSystem.h"
+
+// Updating process for CSampleRotateComponent
+void CSampleRotateComponent::Update() {
+    Quaternionf rotate = m_gameObj->GetTransform().rotation;
+    rotate.AngleAxis(m_speed * (float)CAppClock::GetMain().GetDeltaTime(), m_axis);
+    m_gameObj->SetRotation(rotate);
+}
+
+// Starting process for CSampleAnimComponent
+void CSampleAnimComponent::Start() {
+    // Initialize variable
+    m_currentAnimID = 0;
+
+    // Get model component and play animation
+    m_model = m_gameObj->GetComponent<CSkeletalModel>();
+    m_model->GetController()->Play(m_currentAnimID, true);
+}
+
+// Updating process for CSampleAnimComponent
+void CSampleAnimComponent::Update() {
+    // Change animation
+    if (CInputSystem::GetMain().IsKeyDown('K')) {
+        m_currentAnimID = (m_currentAnimID + 1) % 2;
+        m_model->GetController()->Play(m_currentAnimID, true);
+    }
+
+    // Bind pose
+    if (CInputSystem::GetMain().IsKeyDown('N')) {
+        m_model->GetController()->BindPose();
+    }
+}

--- a/MakinoProject00/MakinoProject00/SampleComponent.h
+++ b/MakinoProject00/MakinoProject00/SampleComponent.h
@@ -1,0 +1,67 @@
+/**
+ * @file   SampleComponent.h
+ * @brief  This file handles components for samples not used in the game.
+ * 
+ * @author Shodai Makino
+ * @date   2024/1/11
+ */
+
+#ifndef __SAMPLE_COMPONENT_H__
+#define __SAMPLE_COMPONENT_H__
+
+#include "Component.h"
+#include "Model.h"
+
+/** @brief Component to only keep rotating */
+class CSampleRotateComponent : public ACComponent {
+public:
+    /**
+       @brief Constructor
+       @param obj Game object
+       @param axis Central axis of rotation
+       @param speed Rotation speed
+    */
+    CSampleRotateComponent(CGameObject* obj, Vector3f axis, float speed)
+        : ACComponent(obj), m_axis(axis), m_speed(speed) {}
+
+    /**
+       @brief Starting process
+    */
+    void Start() { }
+
+    /**
+       @brief Updating process
+    */
+    void Update();
+
+private:
+    /** @brief Central axis of rotation */
+    Vector3f m_axis;
+    /** @brief Rotation speed */
+    float m_speed;
+};
+
+/** @brief Component for animation control in the sample scene */
+class CSampleAnimComponent : public ACComponent {
+public:
+    // Using ACComponent constructor
+    using ACComponent::ACComponent;
+
+    /**
+       @brief Starting process
+    */
+    void Start();
+
+    /**
+       @brief Updating process
+    */
+    void Update();
+
+private:
+    /** @brief Weak pointer to CSkeletalModel */
+    CWeakPtr<CSkeletalModel> m_model;
+    /** @brief Animation ID */
+    ModelInfo::AnimID m_currentAnimID;
+};
+
+#endif // !__SAMPLE_COMPONENT_H__

--- a/MakinoProject00/MakinoProject00/SampleScene.cpp
+++ b/MakinoProject00/MakinoProject00/SampleScene.cpp
@@ -1,0 +1,118 @@
+#include "SampleScene.h"
+#include "SampleComponent.h"
+#include "ShaderRegistry.h"
+#include "AssetNameDefine.h"
+
+// Clear color for screen render target
+const Colorf CLEAR_COLOR = Colorf(0.4f, 0.4f, 0.8f, 1.0f);
+
+// Starting process
+void CSampleScene::Start() {
+    // Create dsv
+    ACRenderTarget* backBuffer = CSwapChain::GetAny().GetBackBuffer();
+    m_dsv2D.Create(DXGI_FORMAT_D32_FLOAT, backBuffer->GetWidth(), backBuffer->GetHeight());
+    m_dsv3D.Create(DXGI_FORMAT_D32_FLOAT, backBuffer->GetWidth(), backBuffer->GetHeight());
+
+    // Call prefab function of GPSO wrapper for standard layer
+    m_standardGpso.Prefab(this);
+
+    // Create gpso2D
+    {
+        Gpso::GPSOSetting gpsoSetting2D;
+        gpsoSetting2D.vs = CShaderRegistry::GetAny().GetVS(VertexShaderType::Standard2DSprite);
+        gpsoSetting2D.ps = CShaderRegistry::GetAny().GetPS(PixelShaderType::StandardTex);
+        gpsoSetting2D.rtvFormats.push_back(std::make_pair(DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, Gpso::BlendStateSetting::Alpha));
+        gpsoSetting2D.rasterizerState.cullMode = D3D12_CULL_MODE_BACK;
+        gpsoSetting2D.depth.type = Gpso::DepthTestType::ReadWrite;
+        m_gpsoUI.Create(this, L"UI GPSO", gpsoSetting2D, { GraphicsLayer::UI }, { GraphicsComponentType::SpriteUI });
+    }
+
+    // UI obj
+    {
+        auto obj = CreateGameObject<CGameObject>(Transformf(Vector3f(80.0f, -50.0f, 0.0f), Vector3f::Ones(), Utl::DEG_2_RAD * Vector3f(0.0f, 0.0f, 0.0f)));
+        obj->AddComponent<CSpriteUI>(GraphicsLayer::UI, TEX_NAME_TEST);
+        obj->AddComponent<CSampleRotateComponent>(Vector3f(0.0f, 0.0f, 1.0f).GetNormalize(), 1.5f);
+    }
+    {
+        auto obj = CreateGameObject<CGameObject>(Transformf(Vector3f(70.0f, -40.0f, 0.5f), Vector3f::Ones(), Utl::DEG_2_RAD * Vector3f(0.0f, 0.0f, 0.0f)));
+        obj->AddComponent<CSpriteUI>(GraphicsLayer::UI, TEX_NAME_TEST);
+        obj->AddComponent<CSampleRotateComponent>(Vector3f(0.0f, 0.0f, 1.0f).GetNormalize(), 1.0f);
+    }
+
+    // Sprite obj
+    {
+        auto obj = CreateGameObject<CGameObject>(Transformf(Vector3f(0.0f, 0.0f, 0.0f), Vector3f::Ones(), Utl::DEG_2_RAD * Vector3f(0.0f, 20.0f, 0.0f)));
+        obj->AddComponent<CSprite3D>(GraphicsLayer::Standard, TEX_NAME_TEST2);
+        obj->AddComponent<CSampleRotateComponent>(Vector3f(1.0f, 0.0f, 0.0f).GetNormalize(), 1.0f);
+    }
+    {
+        auto obj = CreateGameObject<CGameObject>(Transformf(Vector3f(0.5f, 0.0f, 0.0f), Vector3f::Ones(), Utl::DEG_2_RAD * Vector3f(45.0f, 0.0f, 0.0f)));
+        obj->AddComponent<CSprite3D>(GraphicsLayer::Standard, TEX_NAME_TEST);
+        obj->AddComponent<CSampleRotateComponent>(Vector3f(0.0f, 1.0f, 0.0f).GetNormalize(), 3.0f);
+    }
+
+    // Billboard obj
+    {
+        auto obj = CreateGameObject<CGameObject>(Transformf(Vector3f(0.0f, -1.5f, 0.0f), Vector3f::Ones(), Utl::DEG_2_RAD * Vector3f(0.0f, 0.0f, 0.0f)));
+        obj->AddComponent<CBillboard>(GraphicsLayer::Standard, TEX_NAME_TEST2);
+    }
+
+    // Box
+    {
+        auto obj = CreateGameObject<CGameObject>(Transformf(Vector3f(0.0f, 0.0f, 0.0f), Vector3f::Ones(), Vector3f::Zero()));
+        obj->AddComponent<CTexShape>(GraphicsLayer::Standard, ShapeKind::Box, TEX_NAME_TEST);
+        obj->AddComponent<CSampleRotateComponent>(Vector3f(1.0f, 1.0f, 0.0f).GetNormalize(), 1.0f);
+    }
+
+    // Capsule
+    {
+        auto obj = CreateGameObject<CGameObject>(Transformf(Vector3f(5.0f, 0.0f, 0.0f), Vector3f::Ones(), Vector3f::Zero()));
+        obj->AddComponent<CColorOnlyShape>(GraphicsLayer::Standard, ShapeKind::Capsule, Colorf(1.0f, 0.0f, 0.0f, 1.0f));
+        obj->AddComponent<CSampleRotateComponent>(Vector3f(1.0f, 1.0f, 0.0f).GetNormalize(), 1.0f);
+    }
+
+    // Desk
+    {
+        auto obj = CreateGameObject<CGameObject>(Transformf(Vector3f(-2.0f, 0.0f, 0.0f), Vector3f::Ones(), Vector3f::Zero()));
+        obj->AddComponent<CBasicModel>(GraphicsLayer::Standard, MODEL_NAME_DESK);
+        obj->AddComponent<CSampleRotateComponent>(Vector3f(0.0f, 1.0f, 0.0f).GetNormalize(), 3.0f);
+    }
+
+    // Skeletal models
+    for (int i = 0; i < 20; ++i) {
+        auto obj = CreateGameObject<CGameObject>(Transformf(Vector3f((float)i - 10.0f, -1.0f, 5.0f), Vector3f::Ones(), Utl::DEG_2_RAD * Vector3f(0.0f, (float)i * 30.0f, 0.0f)));
+        obj->AddComponent<CSkeletalModel>(GraphicsLayer::Standard, MODEL_NAME_UNITYCHAN);
+        obj->AddComponent<CSampleAnimComponent>();
+        obj->AddComponent<CSampleRotateComponent>(Vector3f(0.0f, 1.0f, 0.0f).GetNormalize(), 3.0f);
+    }
+
+    // Main camera obj
+    {
+        auto obj = CreateGameObject<CGameObject>(Transformf(Vector3f(0.0f, 0.0f, -5.0f)));
+        obj->AddComponent<CCameraComponent>(L"Main camera");
+        obj->AddComponent<CSampleRotateComponent>(Vector3f(0.0f, 1.0f, 0.0f), 0.1f);
+    }
+}
+
+// Drawing process
+void CSampleScene::Draw() {
+    // Clear depth stencil views
+    m_dsv3D.Clear();
+    m_dsv2D.Clear();
+
+    // Get current back buffer and clear it
+    ACRenderTarget* rtv = CSwapChain::GetAny().GetBackBuffer();
+    rtv->Clear(CLEAR_COLOR);
+
+    // Apply 3D depth stencil view
+    rtv->Apply(&m_dsv3D);
+
+    // Command function of GPSO wrapper for standard layer
+    m_standardGpso.SetCommand();
+
+    // Apply 2D depth stencil view
+    rtv->Apply(&m_dsv2D);
+
+    // Command function of GPSO for UI
+    m_gpsoUI.SetCommand();
+}

--- a/MakinoProject00/MakinoProject00/SampleScene.h
+++ b/MakinoProject00/MakinoProject00/SampleScene.h
@@ -1,0 +1,39 @@
+/**
+ * @file   SampleScene.h
+ * @brief  This file handles scene class for sample.
+ * 
+ * @author Shodai Makino
+ * @date   2024/1/11
+ */
+
+#ifndef __SAMPLE_SCENE_H__
+#define __SAMPLE_SCENE_H__
+
+#include "Scene.h"
+#include "StandardGPSOWrapper.h"
+
+/** @brief Scene class for sample */
+class CSampleScene : public ACScene {
+public:
+    /**
+       @brief Starting process
+    */
+    void Start() override;
+
+    /**
+       @brief Drawing process
+    */
+    void Draw() override;
+
+private:
+    /** @brief GPSO wrapper for standard layer */
+    CStandardGPSOWrapper m_standardGpso;
+    /** @brief GPSO for UI */
+    CGraphicsPipelineState m_gpsoUI;
+    /** @brief Depth stencil view for 3D */
+    CDepthStencil m_dsv3D;
+    /** @brief Depth stencil view for 2D */
+    CDepthStencil m_dsv2D;
+};
+
+#endif // !__SAMPLE_SCENE_H__

--- a/MakinoProject00/MakinoProject00/StandardGPSOWrapper.cpp
+++ b/MakinoProject00/MakinoProject00/StandardGPSOWrapper.cpp
@@ -1,0 +1,34 @@
+#include "StandardGPSOWrapper.h"
+#include "ShaderRegistry.h"
+
+// Prefab function
+void CStandardGPSOWrapper::Prefab(ACScene* scene) {
+    // Default setting (For BasicModel and TexShape)
+    LayeredGPSOSetting setting({ GraphicsComponentType::BasicModel, GraphicsComponentType::TexShape });
+    setting.defaultSetting.vs = CShaderRegistry::GetAny().GetVS(VertexShaderType::Standard3D);
+    setting.defaultSetting.ps = CShaderRegistry::GetAny().GetPS(PixelShaderType::StandardTex);
+    setting.defaultSetting.rtvFormats.push_back(std::make_pair(DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, Gpso::BlendStateSetting::Alpha));
+    setting.defaultSetting.rasterizerState.cullMode = D3D12_CULL_MODE_BACK;
+    setting.defaultSetting.depth.type = Gpso::DepthTestType::ReadWrite;
+    // Override setting (For SkeletalModel)
+    {
+        auto overrideSetting = setting.AddOverrideSetting({ GraphicsComponentType::SkeletalModel });
+        overrideSetting->vs = CShaderRegistry::GetAny().GetVS(VertexShaderType::Standard3DAnim);
+    }
+    // Override setting (For ColorShape)
+    {
+        auto overrideSetting = setting.AddOverrideSetting({ GraphicsComponentType::ColorShape });
+        overrideSetting->ps = CShaderRegistry::GetAny().GetPS(PixelShaderType::StandardColor);
+    }
+    // Override setting (For Sprite3D and Billboard)
+    {
+        auto overrideSetting = setting.AddOverrideSetting({ GraphicsComponentType::Sprite3D, GraphicsComponentType::Billboard });
+        overrideSetting->vs = CShaderRegistry::GetAny().GetVS(VertexShaderType::Standard3DSprite);
+        overrideSetting->rasterizerState = Gpso::RasterizerStateSetting();
+        overrideSetting->rasterizerState->cullMode = D3D12_CULL_MODE_NONE;
+    }
+
+    // Create
+    CLayeredGPSOWrapper::Create(scene, L"Standard GPSO", setting, { GraphicsLayer::Standard });
+    
+}

--- a/MakinoProject00/MakinoProject00/StandardGPSOWrapper.h
+++ b/MakinoProject00/MakinoProject00/StandardGPSOWrapper.h
@@ -1,0 +1,24 @@
+/**
+ * @file   StandardGPSOWrapper.h
+ * @brief  This file handles GPSO wrap class for standard layer.
+ * 
+ * @author Shodai Makino
+ * @date   2024/1/11
+ */
+
+#ifndef __STANDARD_GPSO_WRAPPER_H__
+#define __STANDARD_GPSO_WRAPPER_H__
+
+#include "LayeredGPSOWrapper.h"
+
+/** @brief GPSO wrap class for standard layer */
+class CStandardGPSOWrapper : public CLayeredGPSOWrapperPrefab {
+public:
+    /**
+       @brief Prefab function
+       @param scene The scene where this GPSO exists
+    */
+    void Prefab(ACScene* scene) override;
+};
+
+#endif // !__STANDARD_GPSO_WRAPPER_H__


### PR DESCRIPTION
# 概要
* LayeredGPSOWrapperをPrefab化するためのクラスを定義
* StandardレイヤーのLayeredGPSOWrapperPrefabクラスを作成
* SampleSceneを作成
* RotateComponentとCAnimComponentをCSampleRotateComponentとCSampleAnimComponentにしてリファクタリング
* ファイル名を直書きしていたのを定数に修正
* ApplicationMainに直書きしていたモデルロード時の設定を別ファイルのModelLoadSetting関数に移行