### PR TITLE
物理エンジン用のサンプルシーンを作成

### DIFF
--- a/MakinoProject00/MakinoProject00/ApplicationMain.cpp
+++ b/MakinoProject00/MakinoProject00/ApplicationMain.cpp
@@ -37,10 +37,12 @@ LRESULT WindowProcedure(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) {
     switch (msg) {
     case WM_KEYDOWN:
         switch (wparam) {
+#if 0
         // Change full screen mode
         case VK_F11:
             CSwapChain::GetMain().SetFullScreen(!CSwapChain::GetAny().IsFullScreen());
             break;
+#endif
         // Exit the application
         case VK_ESCAPE:
             PostQuitMessage(0);

--- a/MakinoProject00/MakinoProject00/Collider3D.cpp
+++ b/MakinoProject00/MakinoProject00/Collider3D.cpp
@@ -3,6 +3,7 @@
 #include "RigidBody.h"
 #include "ColliderWrapper.h"
 #include "PhysicsWorld.h"
+#include "SceneRegistry.h"
 
 // Constructor
 ACCollider3D::ACCollider3D(CGameObject* owner, ColliderType type, const Vector3f& offset)
@@ -60,6 +61,13 @@ void ACCollider3D::Awake() {
 
     // Call callback function at collider initial processing
     m_gameObj->GetCallbackSystem()->InvokeFunction(CALLBACK_COLLIDER_AWAKE);
+
+#ifdef _EDITOR
+    if (CSceneRegistry::GetAny().IsEditorMode()) {
+        UpdateScalingOffset();
+        UpdateScaling();
+    }
+#endif // _EDITOR
 }
 
 // Start processing

--- a/MakinoProject00/MakinoProject00/ForPhysicsObjects.cpp
+++ b/MakinoProject00/MakinoProject00/ForPhysicsObjects.cpp
@@ -1,0 +1,96 @@
+#include "ForPhysicsObjects.h"
+#include "Scene.h"
+#include "AssetNameDefine.h"
+#include "ApplicationClock.h"
+#include "Random.h"
+
+// Interval of generating a physics sample prefab
+const float GENERATE_INTERVAL = 5.0f;
+// Maximum number of generating physics sample prefabs
+const UINT GENERATE_MAX = 100;
+
+// Initialize static member
+UINT CPhysicsSamplePrefabGenerateComponent::ms_currentGeneratedNum = 0;
+
+// Start processing
+void CPhysicsSamplePrefabGenerateComponent::Start() {
+    m_timeCnt = GENERATE_INTERVAL + 0.01f;
+}
+
+// Update processing
+void CPhysicsSamplePrefabGenerateComponent::Update() {
+    m_timeCnt += CAppClock::GetMain().GetAppropriateDeltaTime();
+    if (m_timeCnt >= GENERATE_INTERVAL) {
+        m_timeCnt = 0.0f;
+        if (ms_currentGeneratedNum < GENERATE_MAX) {
+            ms_currentGeneratedNum++;
+
+            // Generate prefab
+            CRandom& random = CRandom::GetMain();
+            auto prefab = GetScene()->CreateGameObject(
+                PREFAB_NAMES_PHYSICS_SAMPLE[random.GenerateRange(0, 2)],
+                Transformf(
+                    GetTransform().pos,
+                    GetTransform().scale,
+                    Vector3f((float)random.GenerateRange(0, 359), (float)random.GenerateRange(0, 359), (float)random.GenerateRange(0, 359)) * Utl::DEG_2_RAD
+                ));
+            prefab->AddComponent<CPhysicsSampleCountComponent>();
+        }
+    }
+}
+
+// Process to be called at instance destruction
+void CPhysicsSampleCountComponent::OnDestroy() {
+    CPhysicsSamplePrefabGenerateComponent::DecrementCurrentGeneratedNum();
+}
+
+// Update processing
+void CAutoDestroyComponent::Update() {
+    if (GetTransform().pos.y() <= -100.0f) {
+        GetScene()->DestroyGameObject(m_gameObj);
+    }
+}
+
+// Prefab function
+void CPhysicsSampleGeneraterPrefab::Prefab() {
+    AddComponent<CPhysicsSamplePrefabGenerateComponent>();
+}
+
+// Sphere prefab for physics sample
+void CPhysicsSampleSpherePrefab::Prefab() {
+    AddComponent<CSphereCollider3D>();
+    AddComponent<CTexShape>(GraphicsLayer::ReadWriteShading, ShapeKind::Sphere, TexName::CHECKERBOARD_TEX);
+    auto rb = AddComponent<CRigidBody>();
+    rb->SetBodyType(RigidBodyType::Dynamic);
+    rb->SetGravityScale(1.0f);
+    rb->SetMass(1.0f);
+    rb->SetMaterial(RigidBodyMaterial(0.5f, 0.0f));
+
+    AddComponent<CAutoDestroyComponent>();
+}
+
+// Capsule prefab for physics sample
+void CPhysicsSampleCapsulePrefab::Prefab() {
+    AddComponent<CCapsuleCollider3D>();
+    AddComponent<CTexShape>(GraphicsLayer::ReadWriteShading, ShapeKind::Capsule, TexName::CHECKERBOARD_TEX);
+    auto rb = AddComponent<CRigidBody>();
+    rb->SetBodyType(RigidBodyType::Dynamic);
+    rb->SetGravityScale(1.0f);
+    rb->SetMass(1.0f);
+    rb->SetMaterial(RigidBodyMaterial(0.5f, 0.0f));
+
+    AddComponent<CAutoDestroyComponent>();
+}
+
+// Box prefab for physics sample
+void CPhysicsSampleBoxPrefab::Prefab() {
+    AddComponent<CBoxCollider3D>();
+    AddComponent<CTexShape>(GraphicsLayer::ReadWriteShading, ShapeKind::Box, TexName::CHECKERBOARD_TEX);
+    auto rb = AddComponent<CRigidBody>();
+    rb->SetBodyType(RigidBodyType::Dynamic);
+    rb->SetGravityScale(1.0f);
+    rb->SetMass(1.0f);
+    rb->SetMaterial(RigidBodyMaterial(0.5f, 0.0f));
+
+    AddComponent<CAutoDestroyComponent>();
+}

--- a/MakinoProject00/MakinoProject00/ForPhysicsObjects.h
+++ b/MakinoProject00/MakinoProject00/ForPhysicsObjects.h
@@ -1,0 +1,114 @@
+/**
+ * @file   ForPhysicsObjects.h
+ * @brief  This file handles objects for physics sample.
+ * 
+ * @author Shodai Makino
+ * @date   2024/2/14
+ */
+
+#ifndef __FOR_PHYSICS_OBJECTS_H__
+#define __FOR_PHYSICS_OBJECTS_H__
+
+#include "GameObject.h"
+#include "Component.h"
+
+/** @brief Names of the physics sample prefab */
+const std::string PREFAB_NAMES_PHYSICS_SAMPLE[3] = { "CPhysicsSampleSpherePrefab", "CPhysicsSampleCapsulePrefab", "CPhysicsSampleBoxPrefab" };
+
+/** @brief This component regularly generates a physics sample prefab */
+class CPhysicsSamplePrefabGenerateComponent : public ACComponent {
+public:
+    using ACComponent::ACComponent;
+
+    /**
+       @brief Start processing
+    */
+    void Start() override;
+
+    /**
+       @brief Update processing
+    */
+    void Update() override;
+
+    /** @brief Decrement current number of the generated physics sample prefabs */
+    static void DecrementCurrentGeneratedNum() { if (ms_currentGeneratedNum > 0) { ms_currentGeneratedNum--; } }
+
+private:
+    /** @brief Current number of the generated physics sample prefabs */
+    static UINT ms_currentGeneratedNum;
+
+    /** @brief Variable for counting time */
+    float m_timeCnt;
+};
+
+/** @brief This component count for generated physics sample prefab */
+class CPhysicsSampleCountComponent : public ACComponent {
+public:
+    using ACComponent::ACComponent;
+
+    /**
+       @brief Process to be called at instance destruction
+    */
+    void OnDestroy() override;
+};
+
+/** @brief Component for automatically destroying objects when the Y-coordinate falls under a certain coordinate */
+class CAutoDestroyComponent : public ACComponent {
+public:
+    using ACComponent::ACComponent;
+
+    /**
+       @brief Update processing
+    */
+    void Update() override;
+};
+
+/** @brief This prefab regularly generates physics sample prefabs */
+class CPhysicsSampleGeneraterPrefab : public CGameObject {
+public:
+    using CGameObject::CGameObject;
+
+    /**
+       @brief Prefab function
+    */
+    void Prefab() override;
+};
+REGISTER_PREFABCLASS(CPhysicsSampleGeneraterPrefab);
+
+ /** @brief Sphere prefab for physics sample */
+class CPhysicsSampleSpherePrefab : public CGameObject {
+public:
+    using CGameObject::CGameObject;
+
+    /**
+       @brief Prefab function
+    */
+    void Prefab() override;
+};
+REGISTER_PREFABCLASS(CPhysicsSampleSpherePrefab);
+
+/** @brief Capsule prefab for physics sample */
+class CPhysicsSampleCapsulePrefab : public CGameObject {
+public:
+    using CGameObject::CGameObject;
+
+    /**
+       @brief Prefab function
+    */
+    void Prefab() override;
+};
+REGISTER_PREFABCLASS(CPhysicsSampleCapsulePrefab);
+
+/** @brief Box prefab for physics sample */
+class CPhysicsSampleBoxPrefab : public CGameObject {
+public:
+    using CGameObject::CGameObject;
+
+    /**
+       @brief Prefab function
+    */
+    void Prefab() override;
+};
+REGISTER_PREFABCLASS(CPhysicsSampleBoxPrefab);
+
+#endif // !__FOR_PHYSICS_OBJECTS_H__

--- a/MakinoProject00/MakinoProject00/MakinoProject00.vcxproj
+++ b/MakinoProject00/MakinoProject00/MakinoProject00.vcxproj
@@ -124,6 +124,7 @@
     <ClCompile Include="DynamicSbAnimMat.cpp" />
     <ClCompile Include="DynamicSbRegistry.cpp" />
     <ClCompile Include="EncryptAssetMain.cpp" />
+    <ClCompile Include="ForPhysicsObjects.cpp" />
     <ClCompile Include="FreeCamera.cpp" />
     <ClCompile Include="GameObject.cpp" />
     <ClCompile Include="GJKAlgorithm.cpp" />
@@ -153,6 +154,7 @@
     <ClCompile Include="ModelLoadSetting.cpp" />
     <ClCompile Include="ModelRegistry.cpp" />
     <ClCompile Include="PhysicsWorld.cpp" />
+    <ClCompile Include="PistonMachine.cpp" />
     <ClCompile Include="PlayerAnimControlComponent.cpp" />
     <ClCompile Include="PlayerCamera.cpp" />
     <ClCompile Include="PlayerControlComponent.cpp" />
@@ -621,6 +623,7 @@
     <ClInclude Include="DynamicSbRegistry.h" />
     <ClInclude Include="Easing.h" />
     <ClInclude Include="EncryptAssetMain.h" />
+    <ClInclude Include="ForPhysicsObjects.h" />
     <ClInclude Include="FreeCamera.h" />
     <ClInclude Include="GameObject.h" />
     <ClInclude Include="GJKAlgorithm.h" />
@@ -653,6 +656,7 @@
     <ClInclude Include="ModelLoadSetting.h" />
     <ClInclude Include="ModelRegistry.h" />
     <ClInclude Include="PhysicsWorld.h" />
+    <ClInclude Include="PistonMachine.h" />
     <ClInclude Include="PlayerAnimControlComponent.h" />
     <ClInclude Include="PlayerCamera.h" />
     <ClInclude Include="PlayerControlComponent.h" />

--- a/MakinoProject00/MakinoProject00/MakinoProject00.vcxproj.filters
+++ b/MakinoProject00/MakinoProject00/MakinoProject00.vcxproj.filters
@@ -241,6 +241,12 @@
     <Filter Include="リソース ファイル\PixelShader\Shading">
       <UniqueIdentifier>{2725d695-6887-4026-8dbb-7ef8ddfbd206}</UniqueIdentifier>
     </Filter>
+    <Filter Include="ソース ファイル\Game\PhysicsSample">
+      <UniqueIdentifier>{6972791c-25be-427c-b252-311c46ac45de}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ヘッダー ファイル\Game\PhysicsSample">
+      <UniqueIdentifier>{0c751879-024c-418f-835a-264d4714d6c7}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Application.cpp">
@@ -620,6 +626,12 @@
     </ClCompile>
     <ClCompile Include="Trees.cpp">
       <Filter>ソース ファイル\Game\Environment</Filter>
+    </ClCompile>
+    <ClCompile Include="PistonMachine.cpp">
+      <Filter>ソース ファイル\Game\PhysicsSample</Filter>
+    </ClCompile>
+    <ClCompile Include="ForPhysicsObjects.cpp">
+      <Filter>ソース ファイル\Game\PhysicsSample</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -1145,6 +1157,12 @@
     </ClInclude>
     <ClInclude Include="Trees.h">
       <Filter>ヘッダー ファイル\Game\Environment</Filter>
+    </ClInclude>
+    <ClInclude Include="PistonMachine.h">
+      <Filter>ヘッダー ファイル\Game\PhysicsSample</Filter>
+    </ClInclude>
+    <ClInclude Include="ForPhysicsObjects.h">
+      <Filter>ヘッダー ファイル\Game\PhysicsSample</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/MakinoProject00/MakinoProject00/PSi_Shading.hlsli
+++ b/MakinoProject00/MakinoProject00/PSi_Shading.hlsli
@@ -36,7 +36,7 @@ static const float SHADOW_FACTOR = 0.3f;
 // Minimum value of shadow bias
 static const float MIN_SHADOW_BIAS = 0.005f;
 // Maximum value of shadow bias
-static const float MAX_SHADOW_BIAS = 0.06f;
+static const float MAX_SHADOW_BIAS = 0.015f;
 
 // Array of offset values (used in soft shadow (PCF))
 static const float2 OFFSETS[9] = {

--- a/MakinoProject00/MakinoProject00/PistonMachine.cpp
+++ b/MakinoProject00/MakinoProject00/PistonMachine.cpp
@@ -1,0 +1,116 @@
+#include "PistonMachine.h"
+#include "ApplicationClock.h"
+#include "Easing.h"
+#include "Shape.h"
+#include "BoxCollider3D.h"
+#include "Scene.h"
+
+// Interval of pushed out
+const float PISTON_INTERVAL = 1.0f;
+// Time of pushed out
+const float PUSHEDOUT_TIME = 0.1f;
+// Cool time of a piston machine
+const float PISTON_COOLTIME = 0.5f;
+// Return time of a piston machine
+const float PISTON_RETURNTIME = 0.5f;
+
+// Power of pushed out
+const float POWER_PUSHEDOUT = 1.25f;
+// High power of pushed out
+const float POWER_PUSHEDOUT_HIGH = 2.0f;
+
+// Constructor
+CPistonMachineComponent::CPistonMachineComponent(CGameObject* owner, float power, float coolTime)
+    : ACComponent(owner)
+    , m_pushedOutPower(power)
+    , m_coolTime(coolTime)
+{ }
+
+// Start processing
+void CPistonMachineComponent::Start() {
+    m_initPos = GetTransform().pos;
+    m_timeCnt = 0.0f;
+    m_isPushedOut = false;
+
+    // Create black box object
+    auto obj = GetScene()->CreateGameObject(Transformf(GetTransform().pos, GetTransform().scale - Vector3f::Ones() * 0.05f, GetTransform().rotation));
+    obj->AddComponent<CColorOnlyShape>(GraphicsLayer::Standard, ShapeKind::Box, Colorf(0.0f, 0.0f, 0.0f, 1.0f));
+}
+
+// Update processing
+void CPistonMachineComponent::Update() {
+    m_timeCnt += CAppClock::GetMain().GetDeltaTime();
+
+    if (!m_isPushedOut) {
+        // Check pushed out time
+        if (m_timeCnt >= PISTON_INTERVAL) {
+
+            // Pushed out this object using easing
+            float time = m_timeCnt - PISTON_INTERVAL;
+            Vector3f outPos = m_initPos + GetTransform().GetUp() * POWER_PUSHEDOUT;
+            if (time < PUSHEDOUT_TIME) {
+                m_gameObj->SetPos(Easing::EaseOutQubic(time, PUSHEDOUT_TIME, m_initPos, outPos));
+            }
+            // Complete pushed out
+            else {
+                m_gameObj->SetPos(outPos);
+                m_timeCnt = 0.0f;
+                m_isPushedOut = true;
+            }
+        }
+    }
+    else {
+        // Check cool time
+        if (m_timeCnt >= PISTON_COOLTIME) {
+            // Begin returnning to the initial position
+            if (!m_beginReturnPos.has_value()) { 
+                m_beginReturnPos = GetTransform().pos; 
+            }
+
+            // Return to the initial position using easing
+            float time = m_timeCnt - PISTON_COOLTIME;
+            if (time < PISTON_RETURNTIME) {
+                m_gameObj->SetPos(Easing::EaseOutQubic(time, PISTON_RETURNTIME, m_beginReturnPos.value(), m_initPos));
+            }
+            // Complete return
+            else {
+                m_gameObj->SetPos(m_initPos);
+                m_timeCnt = 0.0f;
+                m_beginReturnPos = std::nullopt;
+                m_isPushedOut = false;
+            }
+        }
+    }
+}
+
+// Prefab for piston machine
+void CPistonMachinePrefab::Prefab() {
+    AddComponent<CBoxCollider3D>();
+    AddComponent<CColorOnlyShape>(GraphicsLayer::ReadWriteShading, ShapeKind::Box, Colorf(0.5f, 0.5f, 0.5f, 1.0f));
+    auto rb = AddComponent<CRigidBody>();
+    rb->SetBodyType(RigidBodyType::Dynamic);
+    rb->SetGravityScale(0.0f);
+    rb->SetIsPseudoVelocity(true);
+    rb->SetMass(100.0f);
+    rb->SetMaterial(RigidBodyMaterial(0.5f, 1.0f));
+    rb->SetRotateLock(RigidBodyAxisLock::Flag::ALL);
+    rb->SetMoveLock(RigidBodyAxisLock::Flag::ALL);
+
+    AddComponent<CPistonMachineComponent>(POWER_PUSHEDOUT, PISTON_COOLTIME);
+}
+
+// Prefab for piston machine that has high power
+void CPistonMachineHighPowerPrefab::Prefab() {
+    AddComponent<CBoxCollider3D>();
+    AddComponent<CColorOnlyShape>(GraphicsLayer::ReadWriteShading, ShapeKind::Box, Colorf(1.0f, 0.5f, 0.5f, 1.0f));
+    auto rb = AddComponent<CRigidBody>();
+    rb->SetBodyType(RigidBodyType::Dynamic);
+    rb->SetGravityScale(0.0f);
+    rb->SetIsPseudoVelocity(true);
+    rb->SetMass(100.0f);
+    rb->SetMaterial(RigidBodyMaterial(0.5f, 1.0f));
+    rb->SetRotateLock(RigidBodyAxisLock::Flag::ALL);
+    rb->SetMoveLock(RigidBodyAxisLock::Flag::ALL);
+
+    AddComponent<CPistonMachineComponent>(POWER_PUSHEDOUT_HIGH, 0.0f);
+}

--- a/MakinoProject00/MakinoProject00/PistonMachine.h
+++ b/MakinoProject00/MakinoProject00/PistonMachine.h
@@ -1,0 +1,76 @@
+/**
+ * @file   PistonMachine.h
+ * @brief  This file handles piston machine.
+ * 
+ * @author Shodai Makino
+ * @date   2024/2/14
+ */
+
+#ifndef __PISTON_MACHINE_H__
+#define __PISTON_MACHINE_H__
+
+#include "Component.h"
+#include "RigidBody.h"
+
+/** @brief Component for piston machine */
+class CPistonMachineComponent : public ACComponent {
+public:
+    /**
+       @brief Constructor
+       @param owner Game object that is the owner of this component
+       @param power Power of pushed out
+       @param coolTime Cool time of pushed out
+    */
+    CPistonMachineComponent(CGameObject* owner, float power, float coolTime);
+
+    /**
+       @brief Start processing
+    */
+    void Start() override;
+
+    /**
+       @brief Update processing
+    */
+    void Update() override;
+
+private:
+    /** @brief Cool time of pushed out */
+    float m_coolTime;
+    /** @brief Power of pushed out */
+    float m_pushedOutPower;
+    /** @brief Initial position */
+    Vector3f m_initPos;
+    /** @brief Variable for counting time */
+    float m_timeCnt;
+    /** @brief Is the piston being pushed out? */
+    bool m_isPushedOut;
+    /** @brief Position at the beginning of the return */
+    std::optional<Vector3f> m_beginReturnPos;
+};
+
+/** @brief Prefab for piston machine */
+class CPistonMachinePrefab : public CGameObject {
+public:
+    using CGameObject::CGameObject;
+
+    /**
+       @brief Prefab function
+    */
+    void Prefab() override;
+};
+REGISTER_PREFABCLASS(CPistonMachinePrefab);
+
+/** @brief Prefab for piston machine that has high power */
+class CPistonMachineHighPowerPrefab : public CGameObject {
+public:
+    using CGameObject::CGameObject;
+
+    /**
+       @brief Prefab function
+    */
+    void Prefab() override;
+};
+REGISTER_PREFABCLASS(CPistonMachineHighPowerPrefab);
+
+#endif // !__PISTON_MACHINE_H__
+

--- a/MakinoProject00/MakinoProject00/PlayerCamera.cpp
+++ b/MakinoProject00/MakinoProject00/PlayerCamera.cpp
@@ -45,6 +45,8 @@ void CPlayerCameraControl::Start() {
         m_cameraComponent->SetFocus(playerPos + Vector3f(0.0f, FOCUS_OFFSET_Y, 0.0f));
     }
 
+    CInputSystem::GetMain().SetIsRepeatCursorInScreen(true);
+
 #ifdef _DEBUG
     //m_focusPointShapeObj = GetScene()->CreateGameObject<CGameObject>(Transformf(m_cameraComponent->GetFocus(), Vector3f::Ones() * 0.1f, Vector3f::Zero()));
     //m_focusPointShapeObj->AddComponent<CColorOnlyShape>(GraphicsLayer::Transparent, ShapeKind::Sphere, Colorf(1.0f, 0.0f, 0.0f, 0.3f));

--- a/MakinoProject00/MakinoProject00/Random.cpp
+++ b/MakinoProject00/MakinoProject00/Random.cpp
@@ -11,6 +11,6 @@ int CRandom::GenerateRange(int min, int max) {
 
 // Constructor
 CRandom::CRandom()
-    : ACSingletonBase(0)
+    : ACMainThreadSingleton(0)
     , m_engine(m_seed_gen())
 { }

--- a/MakinoProject00/MakinoProject00/Random.h
+++ b/MakinoProject00/MakinoProject00/Random.h
@@ -12,7 +12,7 @@
 #include "Singleton.h"
 
  // Random value generator
-class CRandom : ACSingletonBase<CRandom> {
+class CRandom : public ACMainThreadSingleton<CRandom> {
     // Friend declaration
     friend class ACSingletonBase;
 

--- a/MakinoProject00/MakinoProject00/UtilityForFile.cpp
+++ b/MakinoProject00/MakinoProject00/UtilityForFile.cpp
@@ -8,29 +8,32 @@ bool Utl::File::GetMatchExtensionInDirectory(std::vector<std::string>* ret,
     ret->clear();
 
     bool isOne = false;
-    for (const auto& entry : std::filesystem::directory_iterator(directory)) {
-        // Get file path
-        auto path = entry.path();
-        // Check if the file extension is correct
-        bool isTrueExtension = false;
-        for (const auto& it : extensions) {
-            if (path.extension() == it) {
-                isTrueExtension = true;
-                break;
+    if (std::filesystem::exists(directory) && std::filesystem::is_directory(directory)) {
+        for (const auto& entry : std::filesystem::directory_iterator(directory)) {
+            // Get file path
+            auto path = entry.path();
+            // Check if the file extension is correct
+            bool isTrueExtension = false;
+            for (const auto& it : extensions) {
+                if (path.extension() == it) {
+                    isTrueExtension = true;
+                    break;
+                }
             }
-        }
-        // If the file extension is not correct, advance to a next file
-        if (false == isTrueExtension) {
-            continue;
-        }
+            // If the file extension is not correct, advance to a next file
+            if (false == isTrueExtension) {
+                continue;
+            }
 
-        std::string fileName = path.filename().string();
-        if (isRemoveExtension) {
-            fileName = fileName.substr(0, fileName.find_last_of('.'));
-        }
+            std::string fileName = path.filename().string();
+            if (isRemoveExtension) {
+                fileName = fileName.substr(0, fileName.find_last_of('.'));
+            }
 
-        ret->push_back(fileName);
-        isOne = true;
+            ret->push_back(fileName);
+            isOne = true;
+        }
     }
+
     return isOne;
 }


### PR DESCRIPTION
# 概要
* 物理エンジン用のサンプルシーンを作成
* エディタのウィンドウを少しだけ整えました

# 修正
* スケール変更後にPrefab選択をするとコライダーの描画がスケールを考慮しない問題を修正
* PlayerCameraの回転が画面の端で止まらないように修正
* Randomクラスがシングルトンを正しく継承していなかったのを修正
* workingディレクトリが存在しないときにシーンをバックアップ用セーブするとエラーになる問題を修正